### PR TITLE
refactor and playground

### DIFF
--- a/src/cats.js
+++ b/src/cats.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/* exported makeCat, cats */
+
+const cats = [
+  { name: 'Claude', pic: 'i/1.png' },
+  { name: 'Colin', pic: 'i/2.png' },
+  { name: 'Fluffy', pic: 'i/3.png' },
+  { name: 'Ghengis', pic: 'i/4.png' },
+  { name: 'Madge', pic: 'i/5.png' },
+  { name: 'Penny', pic: 'i/6.png' },
+  { name: 'Roger', pic: 'i/7.png' },
+  { name: 'Top', pic: 'i/8.png' },
+];
+
+// give every cat an index that reflects its position in the array
+cats.forEach((c, idx) => c.index = idx);
+
+
+/**
+ * Makes a kitten element.
+ * @param {object} cat contains details on the cat to be added
+ * @param {function} dragStartHandler what to call when dragging starts
+ * @return {Element}
+ */
+function makeCat(cat, dragStartHandler) {
+  const kitty = document.createElement('figure');
+  const pic = document.createElement('img');
+  const nom = document.createElement('figcaption');
+
+  cat.id = `cat${cat.index}`;
+  kitty.id = cat.id;
+  kitty.className = 'cat';
+  kitty.draggable = true;
+  kitty.dataset.cat = JSON.stringify(cat);
+  kitty.addEventListener('dragstart', dragStartHandler);
+
+  nom.textContent = cat.name;
+
+  pic.src = cat.pic;
+  pic.alt = 'A cat';
+  pic.draggable = false; // images are by default draggable, but we want to drag the whole kitty figure
+
+  kitty.appendChild(pic);
+  kitty.appendChild(nom);
+  return kitty;
+}
+

--- a/src/cats.js
+++ b/src/cats.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* exported makeCat, cats */
+/* exported makeCat, cats, isCatInPlayground, addCatToPlayground, removeCatFromPlayground */
 
 const cats = [
   { name: 'Claude', pic: 'i/1.png' },
@@ -46,3 +46,55 @@ function makeCat(cat, dragStartHandler) {
   return kitty;
 }
 
+
+/**
+ * @param {number} catIndex
+ * @return {boolean}
+ */
+function isCatInPlayground(catIndex) {
+  return listCatsInPlayground().includes(catIndex);
+}
+
+
+/**
+ * @param {number} catIndex cat number
+ * @param {number} pen which playground pen the cat is in (0..2)
+ */
+function addCatToPlayground(catIndex, pen) {
+  const catsInPlayground = listCatsInPlayground();
+  const oldPos = catsInPlayground.indexOf(catIndex);
+  if (oldPos !== -1) {
+    catsInPlayground[oldPos] = null;
+  }
+  catsInPlayground[pen] = catIndex;
+  saveCatsInPlayground(catsInPlayground);
+}
+
+
+/**
+ * @param {number} catIndex cat number
+ */
+function removeCatFromPlayground(catIndex) {
+  const catsInPlayground = listCatsInPlayground();
+  const pos = catsInPlayground.indexOf(catIndex);
+  if (pos !== -1) {
+    catsInPlayground[pos] = null;
+    saveCatsInPlayground(catsInPlayground);
+  }
+}
+
+
+/**
+ * @return {boolean}
+ */
+function listCatsInPlayground() {
+  return JSON.parse(localStorage.catsInPlayground || '[]');
+}
+
+
+/**
+ * @param {Array} cats
+ */
+function saveCatsInPlayground(cats) {
+  localStorage.catsInPlayground = JSON.stringify(cats);
+}

--- a/src/css/grid.css
+++ b/src/css/grid.css
@@ -8,13 +8,16 @@ main {
   height: 100vh;
   width: 100vw;
   display: grid;
+  grid-gap: 1ex;
+  padding: 1ex;
+  box-sizing: border-box;
+}
+
+main.clowder-vet {
   grid-template:
-    "  .  .        .      .      .  " 1vmin
-    "  .  intro    intro  intro  .  " auto
-    "  .  .        .      .      .  " 1vmin
-    "  .  clowder  .      vet    .  " 1fr
-    "  .  .        .      .      .  " 1vmin
-    / 1vmin 1fr 1vmin 1fr 1vmin;
+    " intro   intro " auto
+    " clowder vet   " 1fr
+    / 1fr 1fr;
 }
 
 #clowder,

--- a/src/css/grid.css
+++ b/src/css/grid.css
@@ -20,6 +20,39 @@ main.clowder-vet {
     / 1fr 1fr;
 }
 
+main.playground {
+  grid-template:
+    " intro intro intro " auto
+    " .     .     .     " 1fr
+    / 1fr 1fr 1fr;
+}
+
+@media screen and (max-width: 30em) {
+  main.playground {
+    grid-template:
+      " intro " auto
+      " .     " 1fr
+      " .     " 1fr
+      " .     " 1fr
+      / 1fr;
+  }
+
+  .pen > h1,
+  .pen > p {
+    display: inline;
+  }
+
+  .pen > h1 {
+    font-size: 120%;
+  }
+
+  .pen > p::before { content: '–'; }
+
+  .pen > .cat {
+    display: block;
+  }
+}
+
 #clowder,
 #vet {
   position: relative;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -19,7 +19,7 @@ body {
   overflow: hidden;
   margin: 1ex;
   padding: 0;
-  max-width: 4em;
+  max-width: 5em;
 }
 
 .cat figcaption {

--- a/src/index.html
+++ b/src/index.html
@@ -4,9 +4,10 @@
 
 <link href=css/index.css rel=stylesheet>
 
+<script src=cats.js></script>
 <script src=app.js></script>
 
-<main>
+<main class="clowder-vet">
 
   <div id=intro>
     <h1>Drag-a-Cat™️</h1>

--- a/src/playground.html
+++ b/src/playground.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Drag-a-Cat Playground</title>
+
+<link href=css/index.css rel=stylesheet>
+
+<script src=cats.js></script>
+<script src=playground.js></script>
+
+<main class="playground">
+  <div id=intro>
+    <h1>Drag-a-Cat™️ Playground</h1>
+    <p>
+      Every good cat deserves play. Bring your cat to our premiere cat playground.
+    </p>
+  </div>
+
+  <div class="pen">
+    <h1>Tuna pen</h1>
+    <p>
+      Sea view, lots of fish toys to play with.
+    </p>
+  </div>
+
+  <div class="pen">
+    <h1>Friends pen</h1>
+    <p>
+      In between two cat pals, with mirrors for seeing more of your pals and yourself.
+    </p>
+  </div>
+
+  <div class="pen">
+    <h1>Houseview pen</h1>
+    <p>
+      Facing the house, with mouse toys and often little humans to play with.
+    </p>
+  </div>
+
+</main>


### PR DESCRIPTION
fixes #3 

Some changes I've pushed before this PR, and the changes in this PR, make some behaviour cleaner at the cost of more code. Feel free to suggest what bits we don't want (e.g. highlighting of dragged cat or current target drop zone) and I'll be happy to factor them out.

The normal app (clowder and vet) has only a few lines (9 at the latest count) affected by the presence of the playground extension, and I think we can explain them naturally in the lecture. 

`playground.js` is a copy of `app.js` with much overlap; it might be useful to show these side-by-side in the lecture to show how the playground differs from the normal app. The diff between the two files is quite short. I have intentionally not tried to factor all commonalities out because that would make the code for the normal app less natural (because it would have to be more generic because of the presence of the playground).

Comments welcome.